### PR TITLE
メッセージの自動更新機能の追加

### DIFF
--- a/app/assets/javascripts/chat.js
+++ b/app/assets/javascripts/chat.js
@@ -52,7 +52,7 @@ $(function() {
 
   function update(){
     if (window.location.href.match(/\/groups\/\d+\/messages/)){
-      var lastMessageId = $('.chat_body').last().data('message-id') || 0;
+      var lastMessageId = $('.chat_body:last').data('message-id') || 0;
       $.ajax({
         url: location.href,
         type: 'GET',
@@ -61,12 +61,9 @@ $(function() {
       })
       .done(function(data){
         data.forEach(function(message) {
-        console.log(message);
-          if(message.id>lastMessageId){
-            var html = buildHTML(message);
-            $('.chats').append(html);
-            $('.chat').animate({scrollTop: $('.chat')[0].scrollHeight}, 'fast');
-          }
+          var html = buildHTML(message);
+          $('.chats').append(html);
+          $('.chat').animate({scrollTop: $('.chat')[0].scrollHeight}, 'fast');
         });
       })
       .fail(function(data){

--- a/app/assets/javascripts/chat.js
+++ b/app/assets/javascripts/chat.js
@@ -57,27 +57,21 @@ $(function() {
     if (window.location.href.match(/\/groups\/\d+\/messages/)){
       if($('.chat_body')[0]){
         var message_id = $('.chat_body:last').data('message-id');
-      }else{
-        var message_id = 0;
       }
 
-      console.log(message_id);
       $.ajax({
-        url: location.href.json,
+        url: location.href,
         type: 'GET',
-        data: {
-          message: {id: message_id}
-        },
+        data: {  message: {id: message_id} },
         dataType: 'json',
       })
       .done(function(data){
-        console.log(data);
         var insertHTML = '';
         $.each(data, function(i, message){
-          insertHTML += buildHTML(message);
+          var html = buildHTML(message);
+          $('.chats').append(html);
+          $('.chat').animate({scrollTop: $('.chat')[0].scrollHeight}, 'fast');
         });
-        $('.chats').html(insertHTML);
-        $('.chat').animate({scrollTop: $('.chat')[0].scrollHeight}, 'fast');
       })
       .fail(function(data){
         alert('自動更新に失敗しました');

--- a/app/assets/javascripts/chat.js
+++ b/app/assets/javascripts/chat.js
@@ -4,7 +4,7 @@ $(function() {
     var insertImage =
       (message.image) ? `<img src="${message.image}">` : '';
       var html =
-      `<li class="chat_body">
+      `<li class="chat_body" >
         <span class="user_name">
           ${message.user_name}
         </span>
@@ -42,9 +42,50 @@ $(function() {
       $("form")[0].reset();
       })
     .fail(function(data){
-      alert('自動更新に失敗しました')
+      alert('非同期投稿に失敗しました')
     })
-
     return false;
   })
+
+  var interval;
+
+  $(function(){
+    interval = setInterval(update, 5000);
+  });
+
+  function update(){
+    if (window.location.href.match(/\/groups\/\d+\/messages/)){
+      if($('.chat_body')[0]){
+        var message_id = $('.chat_body:last').data('message-id');
+      }else{
+        var message_id = 0;
+      }
+
+      console.log(message_id);
+      $.ajax({
+        url: location.href.json,
+        type: 'GET',
+        data: {
+          message: {id: message_id}
+        },
+        dataType: 'json',
+      })
+      .done(function(data){
+        console.log(data);
+        var insertHTML = '';
+        $.each(data, function(i, message){
+          insertHTML += buildHTML(message);
+        });
+        $('.chats').html(insertHTML);
+        $('.chat').animate({scrollTop: $('.chat')[0].scrollHeight}, 'fast');
+      })
+      .fail(function(data){
+        alert('自動更新に失敗しました');
+      });
+    } else{
+      clearInterval(interval);
+    }
+  }
+
+
 })

--- a/app/assets/javascripts/chat.js
+++ b/app/assets/javascripts/chat.js
@@ -53,7 +53,6 @@ $(function() {
   function update(){
     if (window.location.href.match(/\/groups\/\d+\/messages/)){
       var lastMessageId = $('.chat_body').last().data('message-id') || 0;
-      console.log(lastMessageId);
       $.ajax({
         url: location.href,
         type: 'GET',

--- a/app/assets/javascripts/chat.js
+++ b/app/assets/javascripts/chat.js
@@ -53,12 +53,7 @@ $(function() {
 
   function update(){
     if (window.location.href.match(/\/groups\/\d+\/messages/)){
-      if($('.chat_body')[0]){
-        var message_id = $('.chat_body:last').data('message-id');
-      }
-      else{
-        var message_id = 0;
-      }
+      var message_id = ($('.chat_body')[0]) ? ($('.chat_body:last').data('message-id')):0;
 
       $.ajax({
         url: location.href,
@@ -76,7 +71,8 @@ $(function() {
       .fail(function(data){
         alert('自動更新に失敗しました');
       });
-    } else{
+    }
+    else{
       clearInterval(interval);
     }
   }

--- a/app/assets/javascripts/chat.js
+++ b/app/assets/javascripts/chat.js
@@ -53,12 +53,12 @@ $(function() {
 
   function update(){
     if (window.location.href.match(/\/groups\/\d+\/messages/)){
-      var new_message = ($('.chat_body')[0]) ? ($('.chat_body:last').data('message-id')):0;
+      if (($('.chat_body')[0])){ var updated_id = ($('.chat_body:last').data('message-id')) || 0;}
 
       $.ajax({
         url: location.href,
         type: 'GET',
-        data: {  message: {id: new_message} },
+        data: {  message: {id: updated_id} },
         dataType: 'json',
       })
       .done(function(data){

--- a/app/assets/javascripts/chat.js
+++ b/app/assets/javascripts/chat.js
@@ -53,12 +53,12 @@ $(function() {
 
   function update(){
     if (window.location.href.match(/\/groups\/\d+\/messages/)){
-      var message_id = ($('.chat_body')[0]) ? ($('.chat_body:last').data('message-id')):0;
+      var new_message = ($('.chat_body')[0]) ? ($('.chat_body:last').data('message-id')):0;
 
       $.ajax({
         url: location.href,
         type: 'GET',
-        data: {  message: {id: message_id} },
+        data: {  message: {id: new_message} },
         dataType: 'json',
       })
       .done(function(data){

--- a/app/assets/javascripts/chat.js
+++ b/app/assets/javascripts/chat.js
@@ -57,6 +57,8 @@ $(function() {
     if (window.location.href.match(/\/groups\/\d+\/messages/)){
       if($('.chat_body')[0]){
         var message_id = $('.chat_body:last').data('message-id');
+      }else{
+        var message_id = 0;
       }
 
       $.ajax({
@@ -68,9 +70,11 @@ $(function() {
       .done(function(data){
         var insertHTML = '';
         $.each(data, function(i, message){
-          var html = buildHTML(message);
-          $('.chats').append(html);
-          $('.chat').animate({scrollTop: $('.chat')[0].scrollHeight}, 'fast');
+          if (message.id> message_id){
+            var html = buildHTML(message);
+            $('.chats').append(html);
+            $('.chat').animate({scrollTop: $('.chat')[0].scrollHeight}, 'fast');
+          }
         });
       })
       .fail(function(data){
@@ -80,6 +84,4 @@ $(function() {
       clearInterval(interval);
     }
   }
-
-
 })

--- a/app/assets/javascripts/chat.js
+++ b/app/assets/javascripts/chat.js
@@ -4,7 +4,7 @@ $(function() {
     var insertImage =
       (message.image) ? `<img src="${message.image}">` : '';
       var html =
-      `<li class="chat_body" >
+      `<li class="chat_body" data-message-id= "${message.id}">
         <span class="user_name">
           ${message.user_name}
         </span>
@@ -20,7 +20,6 @@ $(function() {
       </li>`;
       return html
     }
-
 
   $('#new_message').on('submit', function(e){
     e.preventDefault();
@@ -53,19 +52,22 @@ $(function() {
 
   function update(){
     if (window.location.href.match(/\/groups\/\d+\/messages/)){
-      if (($('.chat_body')[0])){ var updated_id = ($('.chat_body:last').data('message-id')) || 0;}
-
+      var lastMessageId = $('.chat_body').last().data('message-id') || 0;
+      console.log(lastMessageId);
       $.ajax({
         url: location.href,
         type: 'GET',
-        data: {  message: {id: updated_id} },
+        data: {  message: {id: lastMessageId} },
         dataType: 'json',
       })
       .done(function(data){
-        $.each(data, function(i, message){
+        data.forEach(function(message) {
+        console.log(message);
+          if(message.id>lastMessageId){
             var html = buildHTML(message);
             $('.chats').append(html);
             $('.chat').animate({scrollTop: $('.chat')[0].scrollHeight}, 'fast');
+          }
         });
       })
       .fail(function(data){

--- a/app/assets/javascripts/chat.js
+++ b/app/assets/javascripts/chat.js
@@ -47,17 +47,16 @@ $(function() {
     return false;
   })
 
-  var interval;
-
   $(function(){
-    interval = setInterval(update, 5000);
+    var interval = setInterval(update, 5000);
   });
 
   function update(){
     if (window.location.href.match(/\/groups\/\d+\/messages/)){
       if($('.chat_body')[0]){
         var message_id = $('.chat_body:last').data('message-id');
-      }else{
+      }
+      else{
         var message_id = 0;
       }
 
@@ -68,13 +67,10 @@ $(function() {
         dataType: 'json',
       })
       .done(function(data){
-        var insertHTML = '';
         $.each(data, function(i, message){
-          if (message.id> message_id){
             var html = buildHTML(message);
             $('.chats').append(html);
             $('.chat').animate({scrollTop: $('.chat')[0].scrollHeight}, 'fast');
-          }
         });
       })
       .fail(function(data){

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -5,7 +5,7 @@ class MessagesController < ApplicationController
     @messages = @group.messages.includes(:user)
     respond_to do |format|
       format.html
-      format.json{@new_message = Message.where('id > ?', params[:message][:id])}
+      format.json{@new_message = @messages.where('id > ?', params[:message][:id])}
     end
   end
 

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -5,7 +5,7 @@ class MessagesController < ApplicationController
     @messages = @group.messages.includes(:user)
     respond_to do |format|
       format.html
-      format.json{@new_message = @messages.where('id > ?', params[:message][:id])}
+      format.json
     end
   end
 

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -3,7 +3,6 @@ class MessagesController < ApplicationController
   def index
     @message = Message.new
     @messages = @group.messages.includes(:user)
-     binding.pry
     respond_to do |format|
       format.html
       format.json{@new_message = Message.where('id > ?', params[:message][:id])}

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -3,6 +3,11 @@ class MessagesController < ApplicationController
   def index
     @message = Message.new
     @messages = @group.messages.includes(:user)
+     binding.pry
+    respond_to do |format|
+      format.html
+      format.json{@new_message = Message.where('id > ?', params[:message][:id])}
+    end
   end
 
   def create

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -5,7 +5,7 @@ class MessagesController < ApplicationController
     @messages = @group.messages.includes(:user)
     respond_to do |format|
       format.html
-      format.json
+      format.json{ @new_message = @messages.where('id > ?', params[:message][:id]) }
     end
   end
 

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -2,7 +2,7 @@
   %span.user_name
     = message.user.name
   %span.update_at
-    = message.created_at.strftime("%Y/%m/%d %H:%M")
+    = message.created_at.to_s
   %div.message
     - if message.content.present?
       %div.message__content

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-%li.chat_body
+%li.chat_body{"data-message-id": "#{message.id}"}
   %span.user_name
     = message.user.name
   %span.update_at

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,4 +1,5 @@
+json.id             @message.id
 json.user_name      @message.user.name
 json.content        @message.content
-json.date           @message.created_at.strftime("%Y/%m/%d %H:%M")
+json.date           @message.created_at.to_s
 json.image          @message.image.url

--- a/app/views/messages/index.json.jbuilder
+++ b/app/views/messages/index.json.jbuilder
@@ -1,9 +1,7 @@
-if @new_message.present?
-  json.array! @new_message.each do |message|
+json.array! @new_message.each do |message|
+      json.id             message.id
       json.user_name      message.user.name
       json.content        message.content
-      json.date           message.created_at.strftime("%Y/%m/%d %H:%M")
+      json.date           message.created_at.to_s
       json.image          message.image.url
-      json.id             message.id
-  end
 end

--- a/app/views/messages/index.json.jbuilder
+++ b/app/views/messages/index.json.jbuilder
@@ -1,4 +1,4 @@
-json.array! @new_message.each do |message|
+json.array! @messages.each do |message|
       json.id             message.id
       json.user_name      message.user.name
       json.content        message.content

--- a/app/views/messages/index.json.jbuilder
+++ b/app/views/messages/index.json.jbuilder
@@ -1,4 +1,4 @@
-json.array! @messages.each do |message|
+json.array! @new_message.each do |message|
       json.id             message.id
       json.user_name      message.user.name
       json.content        message.content

--- a/app/views/messages/index.json.jbuilder
+++ b/app/views/messages/index.json.jbuilder
@@ -1,11 +1,9 @@
 if @new_message.present?
-  json.array! @new_message
+  json.array! @new_message.each do |message|
+      json.user_name      message.user.name
+      json.content        message.content
+      json.date           message.created_at.strftime("%Y/%m/%d %H:%M")
+      json.image          message.image.url
+      json.id             message.id
+  end
 end
-
-# json.messages @messages.each do |message|
-#   json.user_name      message.user.name
-#   json.content        message.content
-#   json.date           message.created_at.strftime("%Y/%m/%d %H:%M")
-#   json.image          message.image.url
-#   json.id             message.id
-# end

--- a/app/views/messages/index.json.jbuilder
+++ b/app/views/messages/index.json.jbuilder
@@ -1,0 +1,11 @@
+if @new_message.present?
+  json.array! @new_message
+end
+
+# json.messages @messages.each do |message|
+#   json.user_name      message.user.name
+#   json.content        message.content
+#   json.date           message.created_at.strftime("%Y/%m/%d %H:%M")
+#   json.image          message.image.url
+#   json.id             message.id
+# end

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,0 +1,1 @@
+Time::DATE_FORMATS[:default] = '%Y/%m/%d %H:%M'


### PR DESCRIPTION
# WHAT
### グループのindexを自動で更新する機能をつけた。
-  messageのindexのビューの時に、定期的にページを更新する。
- 新しいメッセージがある場合はその差分を挿入するようにした。
# WHY
- メッセージを自動更新にすることで、リアルタイムのチャットを可能にするため。
